### PR TITLE
error handling for non-existent users/posts

### DIFF
--- a/backend/routes/api/follows.js
+++ b/backend/routes/api/follows.js
@@ -12,7 +12,6 @@ const router = express.Router();
 router.get('/:userId', asyncHandler(async(req,res) => {
     const {userId} = req.params;
     const follows = await User.findByPk(userId, {include: [{model: User, as: 'followed'}, {model: User, as: 'followers'}]})
-    
     res.json(follows);
 }))
 

--- a/backend/routes/api/users.js
+++ b/backend/routes/api/users.js
@@ -46,6 +46,13 @@ router.post(
   }),
 );
 
+router.get('/:userId/validate', asyncHandler(async(req,res) => {
+  const {userId} = req.params;
+  const user = await User.findByPk(userId)
+  if(!user) res.json({msg: false})
+  res.json(user)
+}))
+
 
 router.get("", asyncHandler(async(req,res) => {
   const posts = await Post.findAll({order:[['createdAt','DESC']],include:[{model:User}, {model:Like}, {model:Dislike}, {model:Comment, include: User}]})
@@ -54,7 +61,9 @@ router.get("", asyncHandler(async(req,res) => {
 
 router.get('/:userId', asyncHandler(async(req,res) => {
   const {userId} = req.params;
+  const user = await User.findByPk(+userId)
   const userPosts = await Post.findAll({where:{userId}, include: [User]})
+  // userPosts.dataValues['User'] = user
   res.json(userPosts)
 }))
 
@@ -80,10 +89,6 @@ router.patch('/:userId/edit', validateProfile, requireAuth, asyncHandler(async(r
 router.get('/posts/:postId', asyncHandler(async(req,res) => {
   const {postId} = req.params;
   const post = await Post.findByPk(postId, {include:[{model:Like}, {model:User}, {model:Dislike}, {model:Comment, include: User}]});
-  if(!post) {
-    res.status(404)
-    res.json({msg: 'Not Found'})
-  }
   res.json(post)
 }))
 

--- a/frontend/src/components/EditProfile/EditProfile.js
+++ b/frontend/src/components/EditProfile/EditProfile.js
@@ -8,7 +8,6 @@ import './EditProfile.css';
 const EditProfile = ({user, closeModal}) => {
     const dispatch = useDispatch();
     const currentUser = useSelector((state) => state.session.user)
-    console.log(currentUser.bio, ' is it changing ?')
 const [bio, setBio] = useState(user?.bio ? user?.bio : currentUser.bio)
 const [image, setImage] = useState(user?.image ? user?.image : "https://upload.wikimedia.org/wikipedia/commons/8/89/Portrait_Placeholder.png")
 const [errors, setErrors] = useState('')

--- a/frontend/src/components/FollowUser/FollowUser.js
+++ b/frontend/src/components/FollowUser/FollowUser.js
@@ -19,9 +19,9 @@ const FollowUser = () => {
     const ifFollow = () => {
         const follow = userFollowers?.find((follow) => follow?.id === currentUser.id)
         if(follow ){
-            dispatch(unfollowUser(currentUser.id, userPosts[0]?.User?.id))
+            dispatch(unfollowUser(currentUser.id, userId))
         }else {
-            dispatch(followUser(currentUser.id, userPosts[0]?.User?.id))
+            dispatch(followUser(currentUser.id, userId))
         }
     }
 

--- a/frontend/src/components/SinglePost/SinglePost.js
+++ b/frontend/src/components/SinglePost/SinglePost.js
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useState } from "react";
 import Modal from "react-modal";
 import "./SinglePost.css";
-import { useParams, useHistory } from "react-router-dom";
+import { useParams, useHistory, Link} from "react-router-dom";
 import { loadSinglePost } from "../../store/posts";
 import EditPost from "../EditPost/EditPost";
 import { FaUserCircle, FaEllipsisH } from "react-icons/fa";
@@ -47,14 +47,11 @@ const SinglePost = () => {
   }
 
   useEffect(() => {
-    // if(!posts[0]?.User?.id) history.push('/');
-    dispatch(loadSinglePost(postId)).catch(async(err) => {
-      const error = err.json();
-
-    });
+    dispatch(loadSinglePost(postId))
   }, [dispatch]);
 
   return (
+    <> {singlePost?.id ?
     <div id="testing3">
       <div className="one-post-cont ">
         <img className="view-items img single" src={singlePost?.image} />
@@ -137,6 +134,10 @@ const SinglePost = () => {
         </div>
       </div>
     </div>
+   : <div className="no-content">
+   <h2>You must have typed in the wrong url..</h2>
+   <p className="return-p">Return to home <Link className="no-content-lnk" to='/'>Here</Link></p>
+   </div>} </>
   );
 };
 

--- a/frontend/src/components/UserProfile/UserProfile.css
+++ b/frontend/src/components/UserProfile/UserProfile.css
@@ -76,3 +76,28 @@
 .following-btns:hover{
     color:rgb(82, 80, 80);
 }
+
+.no-content{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    margin-top: 80px;
+}
+
+.no-content-lnk{
+    color: black;
+    font-weight: 800;
+    text-decoration: none;
+    border: none;
+    background: none;
+    cursor: pointer;
+}
+
+.no-content-lnk:hover{
+    color: rgb(100, 98, 98);
+}
+
+.return-p{
+    font-size: 20px;
+}

--- a/frontend/src/components/UserProfile/UserProfile.js
+++ b/frontend/src/components/UserProfile/UserProfile.js
@@ -10,15 +10,18 @@ import "./UserProfile.css";
 import FollowUser from "../FollowUser/FollowUser";
 import ViewFollowers from "../ViewFollowers/ViewFollowers";
 import ViewFollowing from "../ViewFollowing/ViewFollowing";
+import { loadAUser } from "../../store/users";
 
 const UserProfile = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const { userId } = useParams();
+  const profileUser = useSelector((state) => state.usersReducer?.User)
   const currentUser = useSelector((state) => state.session.user)
   const userFollowers = useSelector((state) => state.followsReducer?.Follows)
   const userFollowing = useSelector((state) => state.followsReducer?.Following)
-
+  // let usertest;
+  // if(profileUser && !profileUser?.id) history.push('/')
   const userPosts = useSelector((state) =>
     Object.values(state.postsReducer?.Posts)
   );
@@ -70,13 +73,19 @@ const UserProfile = () => {
     },
   };
 
+
+
+
   useEffect(() => {
     dispatch(loadAllUserPosts(userId));
     dispatch(loadAllFollows(userId))
-    // if(!userPosts[0]?.User?.id) history.push('/')
+    dispatch(loadAUser(userId))
+
   }, [dispatch, userId]);
 
+
   return (
+    <> {profileUser?.id ?
     <div className="user-prof-cont">
       <div className="user-top-cont">
         <div className="user-prof-img-cont">
@@ -92,11 +101,11 @@ const UserProfile = () => {
         <div className="user-data-cont">
           <div className="name-follow">
             <div>
-              <b>{userPosts[0]?.User?.username ? userPosts[0]?.User?.username : currentUser?.username}</b>
+              <b>{profileUser?.username}</b>
             </div>
             <FollowUser />
             <div>
-                {(currentUser.id === userPosts[0]?.User?.id || userPosts?.length === 0) &&
+                {(currentUser.id === profileUser?.id) &&
               <FiEdit2
                 className="icons"
                 onClick={() => {
@@ -109,7 +118,7 @@ const UserProfile = () => {
               style={customStyles}
               overlayClassName="modal-delete"
               >
-                  <EditProfile user={userPosts[0]?.User} closeModal={closeModal}/>
+                  <EditProfile user={profileUser} closeModal={closeModal}/>
               </Modal>
             </div>
           </div>
@@ -159,6 +168,10 @@ const UserProfile = () => {
         </div>
       </div>
     </div>
+    : <div className="no-content">
+      <h2>You must have typed in the wrong url..</h2>
+      <p className="return-p">Return to home <Link className="no-content-lnk" to='/'>Here</Link></p>
+      </div>}</>
   );
 };
 

--- a/frontend/src/store/followers.js
+++ b/frontend/src/store/followers.js
@@ -13,7 +13,11 @@ const loadFollows = (follows) => ({
 export const loadAllFollows = (userId) => async dispatch => {
     const response = await csrfFetch(`/api/follows/${userId}`)
     const follows = await response.json();
-    // console.log(follows,' what are all the follows returned', response)
+    if(!follows){
+        return follows
+    }
+    console.log(follows,' what are all the follows returned', response)
+
     dispatch(loadFollows(follows))
 }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -4,12 +4,14 @@ import session from './session'
 import postsReducer from './posts';
 import commentsReducer from './comments';
 import followsReducer from './followers';
+import usersReducer from './users';
 
 const rootReducer = combineReducers({
   session,
   postsReducer,
   commentsReducer,
   followsReducer,
+  usersReducer,
 });
 
 let enhancer;

--- a/frontend/src/store/posts.js
+++ b/frontend/src/store/posts.js
@@ -143,7 +143,7 @@ const loadOnePost = (post) => ({
 export const loadSinglePost = (postId) => async dispatch => {
     const response = await csrfFetch(`/api/users/posts/${postId}`)
     const post = await response.json()
-    if(response.ok){
+    if(post){
         dispatch(loadOnePost(post))
     }else {
         return post

--- a/frontend/src/store/session.js
+++ b/frontend/src/store/session.js
@@ -3,6 +3,18 @@ import { csrfFetch } from "./csrf.js";
 const SET_USER = 'session/setUser';
 const REMOVE_USER = 'session/removeUser';
 const EDIT_USER_PROFILE = 'user/EDIT_USER_PROFILE';
+const CHECK_USER = 'user/CHECK_USER';
+
+const checkUser = () => ({
+  type: CHECK_USER,
+})
+
+export const validateUserExists = (userId) => async dispatch => {
+  const response = await csrfFetch(`/api/users/${userId}/validate`)
+  const data = await response.json();
+  return data
+  console.log(data, ' what is repsone?')
+}
 
 const setUser = (user) => ({
   type: SET_USER,

--- a/frontend/src/store/users.js
+++ b/frontend/src/store/users.js
@@ -1,0 +1,35 @@
+import { csrfFetch } from "./csrf";
+
+
+
+const LOAD_USER = 'user/LOAD_USER';
+
+const loadUser = (user) => ({
+  type: LOAD_USER,
+  user
+})
+
+export const loadAUser = (userId) => async dispatch => {
+  const response = await csrfFetch(`/api/users/${userId}/validate`)
+  const data = await response.json();
+  if(data){
+      console.log(data, 'wahts returned ?')
+      dispatch(loadUser(data))
+  }
+}
+
+const initialState = { User: null };
+
+function usersReducer(state = initialState, action){
+    let newState;
+    switch(action.type){
+        case LOAD_USER:
+            newState = {...state}
+            newState.User = action.user
+            return newState;
+        default:
+            return state;
+    }
+}
+
+export default usersReducer;


### PR DESCRIPTION
Added route to load a single user, if no user does not exists cannot view information and are prompted to return home. if no post for a user exists you are also prompted to return home. added minor styling. fixed bugs with following a user with no posts and showing proper username when no posts exists 